### PR TITLE
feat(lib): implement search orchestrator (Task 1.8)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,103 @@ pub mod config;
 pub mod parse;
 pub mod search;
 
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
 // Re-export commonly used types
 pub use config::default_patterns;
 pub use parse::{KeyExtractor, TranslationEntry, YamlParser};
 pub use search::{CodeReference, Match, PatternMatcher, TextSearcher};
+
+/// Query parameters for searching
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    pub text: String,
+    pub case_sensitive: bool,
+    pub base_dir: Option<PathBuf>,
+}
+
+impl SearchQuery {
+    pub fn new(text: String) -> Self {
+        Self {
+            text,
+            case_sensitive: false,
+            base_dir: None,
+        }
+    }
+
+    pub fn with_case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.case_sensitive = case_sensitive;
+        self
+    }
+
+    pub fn with_base_dir(mut self, base_dir: PathBuf) -> Self {
+        self.base_dir = Some(base_dir);
+        self
+    }
+}
+
+/// Result of a search operation
+#[derive(Debug)]
+pub struct SearchResult {
+    pub query: String,
+    pub translation_entries: Vec<TranslationEntry>,
+    pub code_references: Vec<CodeReference>,
+}
+
+/// Main orchestrator function that coordinates the entire search workflow
+///
+/// This function:
+/// 1. Searches for translation entries matching the query text
+/// 2. Extracts translation keys from YAML files
+/// 3. Finds code references for each translation key
+/// 4. Returns a SearchResult with all findings
+pub fn run_search(query: SearchQuery) -> Result<SearchResult> {
+    // Determine the base directory to search
+    let base_dir = query.base_dir.clone().unwrap_or_else(|| {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    });
+
+    // Step 1: Extract translation entries matching the search text
+    let extractor = KeyExtractor::new();
+    let translation_entries = extractor
+        .extract(&base_dir, &query.text)
+        .context("Failed to extract translation entries")?;
+
+    if translation_entries.is_empty() {
+        return Ok(SearchResult {
+            query: query.text,
+            translation_entries: vec![],
+            code_references: vec![],
+        });
+    }
+
+    // Step 2: Find code references for each translation entry
+    let matcher = PatternMatcher::new();
+    let mut all_code_refs = Vec::new();
+
+    for entry in &translation_entries {
+        let code_refs = matcher
+            .find_usages(&entry.key)
+            .context(format!("Failed to find usages for key: {}", entry.key))?;
+        all_code_refs.extend(code_refs);
+    }
+
+    Ok(SearchResult {
+        query: query.text,
+        translation_entries,
+        code_references: all_code_refs,
+    })
+}
+
+/// Helper function to filter translation files from search results
+pub fn filter_translation_files(matches: &[Match]) -> Vec<PathBuf> {
+    matches
+        .iter()
+        .filter(|m| {
+            let path = m.file.to_string_lossy();
+            path.ends_with(".yml") || path.ends_with(".yaml")
+        })
+        .map(|m| m.file.clone())
+        .collect()
+}

--- a/tests/orchestrator_test.rs
+++ b/tests/orchestrator_test.rs
@@ -1,0 +1,186 @@
+use cs::{run_search, SearchQuery};
+use std::path::PathBuf;
+
+#[test]
+fn test_run_search_finds_translation_and_code() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query);
+    assert!(result.is_ok(), "Search should succeed");
+
+    let search_result = result.unwrap();
+    
+    // Should find translation entries
+    assert!(!search_result.translation_entries.is_empty(), 
+        "Should find translation entries for 'add new'");
+    
+    println!("Found {} translation entries", search_result.translation_entries.len());
+    for entry in &search_result.translation_entries {
+        println!("  - {}: {} ({}:{})", 
+            entry.key, entry.value, entry.file.display(), entry.line);
+    }
+    
+    // Should find code references
+    assert!(!search_result.code_references.is_empty(), 
+        "Should find code references");
+    
+    println!("Found {} code references", search_result.code_references.len());
+    for code_ref in &search_result.code_references {
+        println!("  - {}:{} - {}", 
+            code_ref.file.display(), code_ref.line, code_ref.context.trim());
+    }
+}
+
+#[test]
+fn test_run_search_with_no_matches() {
+    let query = SearchQuery::new("nonexistent text xyz".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query);
+    assert!(result.is_ok(), "Search should succeed even with no matches");
+
+    let search_result = result.unwrap();
+    assert!(search_result.translation_entries.is_empty(), 
+        "Should not find translation entries for nonexistent text");
+    assert!(search_result.code_references.is_empty(), 
+        "Should not find code references for nonexistent text");
+}
+
+#[test]
+fn test_run_search_case_insensitive() {
+    let query = SearchQuery::new("ADD NEW".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query);
+    assert!(result.is_ok());
+
+    let search_result = result.unwrap();
+    
+    // Case-insensitive search should find "add new"
+    assert!(!search_result.translation_entries.is_empty(), 
+        "Case-insensitive search should find 'add new'");
+}
+
+#[test]
+fn test_run_search_multiple_keys() {
+    let query = SearchQuery::new("invoice".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query);
+    assert!(result.is_ok());
+
+    let search_result = result.unwrap();
+    
+    // Should find multiple entries containing "invoice"
+    assert!(search_result.translation_entries.len() > 1, 
+        "Should find multiple translation entries containing 'invoice'");
+    
+    println!("Found {} entries containing 'invoice'", search_result.translation_entries.len());
+}
+
+#[test]
+fn test_run_search_finds_all_frameworks() {
+    // Test with the entire fixtures directory to find matches across frameworks
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures"));
+
+    let result = run_search(query);
+    assert!(result.is_ok());
+
+    let search_result = result.unwrap();
+    
+    println!("Found {} translation entries across all fixtures", 
+        search_result.translation_entries.len());
+    println!("Found {} code references across all fixtures", 
+        search_result.code_references.len());
+    
+    // Should find entries from multiple framework fixtures
+    assert!(!search_result.translation_entries.is_empty());
+    
+    // Check if we found references in different frameworks
+    let has_rails = search_result.code_references.iter()
+        .any(|r| r.file.to_string_lossy().contains("rails-app"));
+    let has_react = search_result.code_references.iter()
+        .any(|r| r.file.to_string_lossy().contains("react-app"));
+    let has_vue = search_result.code_references.iter()
+        .any(|r| r.file.to_string_lossy().contains("vue-app"));
+    
+    println!("Found in Rails: {}", has_rails);
+    println!("Found in React: {}", has_react);
+    println!("Found in Vue: {}", has_vue);
+    
+    // At least one framework should have references
+    assert!(has_rails || has_react || has_vue, 
+        "Should find references in at least one framework");
+}
+
+#[test]
+fn test_run_search_with_current_dir() {
+    // Test without specifying base_dir (uses current directory)
+    let query = SearchQuery::new("test".to_string());
+
+    let result = run_search(query);
+    assert!(result.is_ok(), "Search should succeed with current directory");
+}
+
+#[test]
+fn test_search_result_structure() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).unwrap();
+    
+    // Verify SearchResult structure
+    assert_eq!(result.query, "add new");
+    assert!(!result.translation_entries.is_empty());
+    
+    // Verify translation entries have all required fields
+    for entry in &result.translation_entries {
+        assert!(!entry.key.is_empty(), "Key should not be empty");
+        assert!(!entry.value.is_empty(), "Value should not be empty");
+        assert!(entry.line > 0, "Line number should be positive");
+        assert!(entry.file.exists(), "File should exist");
+    }
+    
+    // Verify code references have all required fields
+    for code_ref in &result.code_references {
+        assert!(!code_ref.key_path.is_empty(), "Key path should not be empty");
+        assert!(!code_ref.context.is_empty(), "Context should not be empty");
+        assert!(code_ref.line > 0, "Line number should be positive");
+        assert!(code_ref.file.exists(), "File should exist");
+    }
+}
+
+#[test]
+fn test_end_to_end_workflow_with_orchestrator() {
+    println!("\n=== End-to-End Search Workflow ===\n");
+    
+    let search_text = "add new";
+    let query = SearchQuery::new(search_text.to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+    
+    println!("Searching for: '{}'", search_text);
+    println!("Base directory: tests/fixtures/rails-app\n");
+    
+    let result = run_search(query).unwrap();
+    
+    println!("📝 Translation Entries Found: {}", result.translation_entries.len());
+    for entry in &result.translation_entries {
+        println!("  ✓ {} = '{}'", entry.key, entry.value);
+        println!("    Location: {}:{}", entry.file.display(), entry.line);
+    }
+    
+    println!("\n💻 Code References Found: {}", result.code_references.len());
+    for code_ref in &result.code_references {
+        println!("  ✓ {}", code_ref.key_path);
+        println!("    File: {}:{}", code_ref.file.display(), code_ref.line);
+        println!("    Code: {}", code_ref.context.trim());
+    }
+    
+    println!("\n✅ End-to-end workflow complete!");
+    
+    // Assertions
+    assert!(!result.translation_entries.is_empty());
+    assert!(!result.code_references.is_empty());
+}


### PR DESCRIPTION
- Add run_search() function that coordinates entire workflow
- Add SearchQuery and SearchResult types
- Orchestrator extracts translations and finds code references
- Add comprehensive integration tests (8 tests, all passing)
- Test end-to-end workflow across Rails, React, and Vue fixtures

The orchestrator ties together:
1. KeyExtractor - finds translation entries
2. PatternMatcher - finds code references
3. Returns SearchResult with all findings

Closes #8