### PR TITLE
feat(tree): implement reference tree builder (Task 2.2)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 pub use config::default_patterns;
 pub use parse::{KeyExtractor, TranslationEntry, YamlParser};
 pub use search::{CodeReference, Match, PatternMatcher, TextSearcher};
-pub use tree::{Location, NodeType, ReferenceTree, TreeNode};
+pub use tree::{Location, NodeType, ReferenceTree, ReferenceTreeBuilder, TreeNode};
 
 /// Query parameters for searching
 #[derive(Debug, Clone)]

--- a/src/tree/builder.rs
+++ b/src/tree/builder.rs
@@ -1,0 +1,282 @@
+use crate::tree::{Location, NodeType, ReferenceTree, TreeNode};
+use crate::{CodeReference, SearchResult, TranslationEntry};
+
+/// Builder for constructing reference trees from search results
+pub struct ReferenceTreeBuilder;
+
+impl ReferenceTreeBuilder {
+    /// Build a reference tree from search results
+    ///
+    /// Creates a hierarchical tree structure:
+    /// - Root: search query text
+    ///   - Translation: translation file entry
+    ///     - KeyPath: full translation key
+    ///       - CodeRef: code reference using the key
+    pub fn build(result: &SearchResult) -> ReferenceTree {
+        let mut root = TreeNode::new(NodeType::Root, result.query.clone());
+
+        // Group code references by translation entry key
+        for entry in &result.translation_entries {
+            let mut translation_node = Self::build_translation_node(entry);
+            let mut key_node = Self::build_key_node(entry);
+
+            // Find all code references for this translation key
+            let matching_refs: Vec<_> = result
+                .code_references
+                .iter()
+                .filter(|r| r.key_path == entry.key)
+                .collect();
+
+            // Add code reference nodes as children of the key node
+            for code_ref in matching_refs {
+                let code_node = Self::build_code_node(code_ref);
+                key_node.add_child(code_node);
+            }
+
+            // Only add the key node if it has code references
+            if key_node.has_children() {
+                translation_node.children.push(key_node);
+            }
+
+            root.add_child(translation_node);
+        }
+
+        ReferenceTree::new(root)
+    }
+
+    /// Build a translation node from a translation entry
+    fn build_translation_node(entry: &TranslationEntry) -> TreeNode {
+        let content = format!("{}: '{}'", entry.key, entry.value);
+        let location = Location::new(entry.file.clone(), entry.line);
+
+        TreeNode::with_location(NodeType::Translation, content, location)
+    }
+
+    /// Build a key path node from a translation entry
+    fn build_key_node(entry: &TranslationEntry) -> TreeNode {
+        TreeNode::new(NodeType::KeyPath, entry.key.clone())
+    }
+
+    /// Build a code reference node
+    fn build_code_node(code_ref: &CodeReference) -> TreeNode {
+        let location = Location::new(code_ref.file.clone(), code_ref.line);
+        TreeNode::with_location(NodeType::CodeRef, code_ref.context.clone(), location)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_translation_entry() -> TranslationEntry {
+        TranslationEntry {
+            key: "invoice.labels.add_new".to_string(),
+            value: "add new".to_string(),
+            line: 4,
+            file: PathBuf::from("en.yml"),
+        }
+    }
+
+    fn create_test_code_reference() -> CodeReference {
+        CodeReference {
+            file: PathBuf::from("invoices.ts"),
+            line: 14,
+            pattern: r#"I18n\.t\(['"]([^'"]+)['"]\)"#.to_string(),
+            context: "I18n.t('invoice.labels.add_new')".to_string(),
+            key_path: "invoice.labels.add_new".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_build_translation_node() {
+        let entry = create_test_translation_entry();
+        let node = ReferenceTreeBuilder::build_translation_node(&entry);
+
+        assert_eq!(node.node_type, NodeType::Translation);
+        assert_eq!(node.content, "invoice.labels.add_new: 'add new'");
+        assert!(node.location.is_some());
+        assert_eq!(node.location.unwrap().line, 4);
+    }
+
+    #[test]
+    fn test_build_key_node() {
+        let entry = create_test_translation_entry();
+        let node = ReferenceTreeBuilder::build_key_node(&entry);
+
+        assert_eq!(node.node_type, NodeType::KeyPath);
+        assert_eq!(node.content, "invoice.labels.add_new");
+        assert!(node.location.is_none());
+    }
+
+    #[test]
+    fn test_build_code_node() {
+        let code_ref = create_test_code_reference();
+        let node = ReferenceTreeBuilder::build_code_node(&code_ref);
+
+        assert_eq!(node.node_type, NodeType::CodeRef);
+        assert_eq!(node.content, "I18n.t('invoice.labels.add_new')");
+        assert!(node.location.is_some());
+        assert_eq!(node.location.as_ref().unwrap().line, 14);
+    }
+
+    #[test]
+    fn test_build_tree_single_match() {
+        let result = SearchResult {
+            query: "add new".to_string(),
+            translation_entries: vec![create_test_translation_entry()],
+            code_references: vec![create_test_code_reference()],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        assert_eq!(tree.root.content, "add new");
+        assert_eq!(tree.root.node_type, NodeType::Root);
+        assert_eq!(tree.root.children.len(), 1);
+
+        // Check translation node
+        let translation = &tree.root.children[0];
+        assert_eq!(translation.node_type, NodeType::Translation);
+        assert!(translation.content.contains("invoice.labels.add_new"));
+        assert_eq!(translation.children.len(), 1);
+
+        // Check key path node
+        let key_path = &translation.children[0];
+        assert_eq!(key_path.node_type, NodeType::KeyPath);
+        assert_eq!(key_path.content, "invoice.labels.add_new");
+        assert_eq!(key_path.children.len(), 1);
+
+        // Check code reference node
+        let code_ref = &key_path.children[0];
+        assert_eq!(code_ref.node_type, NodeType::CodeRef);
+        assert!(code_ref.content.contains("I18n.t"));
+    }
+
+    #[test]
+    fn test_build_tree_multiple_code_refs() {
+        let entry = create_test_translation_entry();
+        let code_ref1 = create_test_code_reference();
+        let mut code_ref2 = create_test_code_reference();
+        code_ref2.line = 20;
+        code_ref2.context = "I18n.t('invoice.labels.add_new') // another usage".to_string();
+
+        let result = SearchResult {
+            query: "add new".to_string(),
+            translation_entries: vec![entry],
+            code_references: vec![code_ref1, code_ref2],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        // Should have one translation node
+        assert_eq!(tree.root.children.len(), 1);
+
+        // Translation should have one key path node
+        let translation = &tree.root.children[0];
+        assert_eq!(translation.children.len(), 1);
+
+        // Key path should have two code reference nodes
+        let key_path = &translation.children[0];
+        assert_eq!(key_path.children.len(), 2);
+    }
+
+    #[test]
+    fn test_build_tree_multiple_translations() {
+        let entry1 = create_test_translation_entry();
+        let mut entry2 = create_test_translation_entry();
+        entry2.key = "invoice.labels.edit".to_string();
+        entry2.value = "edit invoice".to_string();
+
+        let code_ref1 = create_test_code_reference();
+        let mut code_ref2 = create_test_code_reference();
+        code_ref2.key_path = "invoice.labels.edit".to_string();
+        code_ref2.context = "I18n.t('invoice.labels.edit')".to_string();
+
+        let result = SearchResult {
+            query: "invoice".to_string(),
+            translation_entries: vec![entry1, entry2],
+            code_references: vec![code_ref1, code_ref2],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        // Should have two translation nodes
+        assert_eq!(tree.root.children.len(), 2);
+
+        // Each translation should have one key path with one code ref
+        for translation in &tree.root.children {
+            assert_eq!(translation.children.len(), 1);
+            assert_eq!(translation.children[0].children.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_build_tree_no_code_refs() {
+        let result = SearchResult {
+            query: "add new".to_string(),
+            translation_entries: vec![create_test_translation_entry()],
+            code_references: vec![],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        // Should have one translation node
+        assert_eq!(tree.root.children.len(), 1);
+
+        // Translation should have no children (no key path without code refs)
+        let translation = &tree.root.children[0];
+        assert_eq!(translation.children.len(), 0);
+    }
+
+    #[test]
+    fn test_build_tree_empty_result() {
+        let result = SearchResult {
+            query: "nonexistent".to_string(),
+            translation_entries: vec![],
+            code_references: vec![],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        assert_eq!(tree.root.content, "nonexistent");
+        assert_eq!(tree.root.children.len(), 0);
+        assert!(!tree.has_results());
+    }
+
+    #[test]
+    fn test_build_tree_structure() {
+        let result = SearchResult {
+            query: "add new".to_string(),
+            translation_entries: vec![create_test_translation_entry()],
+            code_references: vec![create_test_code_reference()],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        // Verify tree structure
+        assert_eq!(tree.node_count(), 4); // root + translation + key + code_ref
+        assert_eq!(tree.max_depth(), 4);
+        assert!(tree.has_results());
+    }
+
+    #[test]
+    fn test_build_tree_filters_unmatched_code_refs() {
+        let entry = create_test_translation_entry();
+        let code_ref1 = create_test_code_reference();
+        let mut code_ref2 = create_test_code_reference();
+        code_ref2.key_path = "different.key".to_string();
+
+        let result = SearchResult {
+            query: "add new".to_string(),
+            translation_entries: vec![entry],
+            code_references: vec![code_ref1, code_ref2],
+        };
+
+        let tree = ReferenceTreeBuilder::build(&result);
+
+        // Should only include the matching code ref
+        let key_path = &tree.root.children[0].children[0];
+        assert_eq!(key_path.children.len(), 1);
+        assert!(key_path.children[0].content.contains("invoice.labels.add_new"));
+    }
+}

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,3 +1,5 @@
+pub mod builder;
 pub mod node;
 
+pub use builder::ReferenceTreeBuilder;
 pub use node::{Location, NodeType, ReferenceTree, TreeNode};

--- a/tests/tree_builder_test.rs
+++ b/tests/tree_builder_test.rs
@@ -1,0 +1,177 @@
+use cs::{run_search, ReferenceTreeBuilder, SearchQuery};
+use std::path::PathBuf;
+
+#[test]
+fn test_build_tree_from_search_result() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+
+    // Verify tree structure
+    assert_eq!(tree.root.content, "add new");
+    assert!(tree.has_results(), "Tree should have results");
+    
+    println!("\n=== Tree Structure ===");
+    println!("Root: {}", tree.root.content);
+    println!("Total nodes: {}", tree.node_count());
+    println!("Max depth: {}", tree.max_depth());
+    println!("Translation entries: {}", tree.root.children.len());
+}
+
+#[test]
+fn test_tree_builder_with_multiple_frameworks() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+
+    println!("\n=== Multi-Framework Tree ===");
+    println!("Query: {}", tree.root.content);
+    println!("Translation entries found: {}", tree.root.children.len());
+    
+    for (i, translation) in tree.root.children.iter().enumerate() {
+        println!("\nTranslation {}:", i + 1);
+        println!("  Content: {}", translation.content);
+        if let Some(loc) = &translation.location {
+            println!("  Location: {}:{}", loc.file.display(), loc.line);
+        }
+        
+        for key_path in &translation.children {
+            println!("  Key: {}", key_path.content);
+            println!("  Code references: {}", key_path.children.len());
+            
+            for (j, code_ref) in key_path.children.iter().take(3).enumerate() {
+                if let Some(loc) = &code_ref.location {
+                    println!("    {}. {}:{}", j + 1, loc.file.display(), loc.line);
+                    println!("       {}", code_ref.content.trim());
+                }
+            }
+            
+            if key_path.children.len() > 3 {
+                println!("    ... and {} more", key_path.children.len() - 3);
+            }
+        }
+    }
+
+    assert!(tree.has_results());
+}
+
+#[test]
+fn test_tree_builder_hierarchy() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+
+    // Verify hierarchy: Root -> Translation -> KeyPath -> CodeRef
+    assert!(!tree.root.children.is_empty(), "Should have translation nodes");
+    
+    let translation = &tree.root.children[0];
+    assert_eq!(translation.node_type, cs::NodeType::Translation);
+    
+    if !translation.children.is_empty() {
+        let key_path = &translation.children[0];
+        assert_eq!(key_path.node_type, cs::NodeType::KeyPath);
+        
+        if !key_path.children.is_empty() {
+            let code_ref = &key_path.children[0];
+            assert_eq!(code_ref.node_type, cs::NodeType::CodeRef);
+        }
+    }
+}
+
+#[test]
+fn test_tree_builder_preserves_locations() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+
+    // Check that translation nodes have locations
+    for translation in &tree.root.children {
+        assert!(translation.location.is_some(), 
+            "Translation node should have location");
+        
+        // Check that code reference nodes have locations
+        for key_path in &translation.children {
+            for code_ref in &key_path.children {
+                assert!(code_ref.location.is_some(), 
+                    "Code reference node should have location");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_tree_builder_with_no_results() {
+    let query = SearchQuery::new("nonexistent xyz abc".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+
+    assert_eq!(tree.root.content, "nonexistent xyz abc");
+    assert!(!tree.has_results(), "Tree should have no results");
+    assert_eq!(tree.node_count(), 1); // Only root node
+    assert_eq!(tree.max_depth(), 1);
+}
+
+#[test]
+fn test_end_to_end_with_tree_builder() {
+    println!("\n=== End-to-End with Tree Builder ===\n");
+    
+    let search_text = "add new";
+    let query = SearchQuery::new(search_text.to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+    
+    println!("1. Running search for: '{}'", search_text);
+    let result = run_search(query).expect("Search should succeed");
+    
+    println!("2. Found {} translation entries", result.translation_entries.len());
+    println!("3. Found {} code references", result.code_references.len());
+    
+    println!("4. Building reference tree...");
+    let tree = ReferenceTreeBuilder::build(&result);
+    
+    println!("5. Tree statistics:");
+    println!("   - Total nodes: {}", tree.node_count());
+    println!("   - Max depth: {}", tree.max_depth());
+    println!("   - Has results: {}", tree.has_results());
+    
+    println!("\n6. Tree structure:");
+    print_tree_node(&tree.root, 0);
+    
+    println!("\n✅ End-to-end workflow with tree builder complete!");
+    
+    assert!(tree.has_results());
+    assert!(tree.node_count() > 1);
+}
+
+fn print_tree_node(node: &cs::TreeNode, depth: usize) {
+    let indent = "  ".repeat(depth);
+    
+    print!("{}", indent);
+    match node.node_type {
+        cs::NodeType::Root => print!("🔍 "),
+        cs::NodeType::Translation => print!("📄 "),
+        cs::NodeType::KeyPath => print!("🔑 "),
+        cs::NodeType::CodeRef => print!("💻 "),
+    }
+    
+    print!("{}", node.content);
+    
+    if let Some(loc) = &node.location {
+        print!(" ({}:{})", loc.file.display(), loc.line);
+    }
+    
+    println!();
+    
+    for child in &node.children {
+        print_tree_node(child, depth + 1);
+    }
+}


### PR DESCRIPTION
- Add ReferenceTreeBuilder to construct trees from SearchResult
- Build hierarchical structure: Root -> Translation -> KeyPath -> CodeRef
- Group code references by translation entry key
- Filter unmatched code references
- Preserve location information for all nodes
- Comprehensive unit tests (10 tests, all passing)
- Integration tests with visual tree output (6 tests)

Tree structure:
🔍 Root (search query)
  📄 Translation (YAML entry with location) 🔑 KeyPath (translation key) 💻 CodeRef (code usage with location)

Closes #10