### PR TITLE
feat(output): implement tree formatter (Task 2.3)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod output;
 pub mod parse;
 pub mod search;
 pub mod tree;
@@ -8,6 +9,7 @@ use std::path::PathBuf;
 
 // Re-export commonly used types
 pub use config::default_patterns;
+pub use output::TreeFormatter;
 pub use parse::{KeyExtractor, TranslationEntry, YamlParser};
 pub use search::{CodeReference, Match, PatternMatcher, TextSearcher};
 pub use tree::{Location, NodeType, ReferenceTree, ReferenceTreeBuilder, TreeNode};

--- a/src/output/formatter.rs
+++ b/src/output/formatter.rs
@@ -1,0 +1,305 @@
+use crate::tree::{NodeType, ReferenceTree, TreeNode};
+
+/// Formatter for rendering reference trees as text
+pub struct TreeFormatter {
+    max_width: usize,
+}
+
+impl TreeFormatter {
+    /// Create a new TreeFormatter with default width (80 columns)
+    pub fn new() -> Self {
+        Self { max_width: 80 }
+    }
+
+    /// Create a TreeFormatter with custom width
+    pub fn with_width(max_width: usize) -> Self {
+        Self { max_width }
+    }
+
+    /// Format a reference tree as a string
+    pub fn format(&self, tree: &ReferenceTree) -> String {
+        let mut output = String::new();
+        self.format_node(&tree.root, &mut output, "", true, true);
+        output
+    }
+
+    /// Format a single node and its children
+    fn format_node(
+        &self,
+        node: &TreeNode,
+        output: &mut String,
+        prefix: &str,
+        is_last: bool,
+        is_root: bool,
+    ) {
+        // Format the current node
+        if !is_root {
+            output.push_str(prefix);
+            output.push_str(if is_last { "└─> " } else { "├─> " });
+        }
+
+        // Add node content
+        let content = self.format_content(node);
+        output.push_str(&content);
+
+        // Add location if present
+        if let Some(location) = &node.location {
+            let location_str = format!(
+                " ({}:{})",
+                location.file.display(),
+                location.line
+            );
+            output.push_str(&location_str);
+        }
+
+        output.push('\n');
+
+        // Format children
+        let child_count = node.children.len();
+        for (i, child) in node.children.iter().enumerate() {
+            let is_last_child = i == child_count - 1;
+            let child_prefix = if is_root {
+                String::new()
+            } else {
+                format!("{}{}   ", prefix, if is_last { " " } else { "│" })
+            };
+
+            self.format_node(child, output, &child_prefix, is_last_child, false);
+        }
+    }
+
+    /// Format node content based on node type
+    fn format_content(&self, node: &TreeNode) -> String {
+        match node.node_type {
+            NodeType::Root => {
+                format!("'{}' (search query)", node.content)
+            }
+            NodeType::Translation => {
+                // Truncate if too long
+                self.truncate(&node.content, self.max_width - 20)
+            }
+            NodeType::KeyPath => {
+                format!("Key: {}", node.content)
+            }
+            NodeType::CodeRef => {
+                // Truncate code context
+                let truncated = self.truncate(&node.content.trim(), self.max_width - 30);
+                format!("Code: {}", truncated)
+            }
+        }
+    }
+
+    /// Truncate a string to fit within max length
+    fn truncate(&self, s: &str, max_len: usize) -> String {
+        if s.len() <= max_len {
+            s.to_string()
+        } else {
+            format!("{}...", &s[..max_len.saturating_sub(3)])
+        }
+    }
+}
+
+impl Default for TreeFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::{Location, TreeNode};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_formatter_creation() {
+        let formatter = TreeFormatter::new();
+        assert_eq!(formatter.max_width, 80);
+    }
+
+    #[test]
+    fn test_formatter_with_custom_width() {
+        let formatter = TreeFormatter::with_width(120);
+        assert_eq!(formatter.max_width, 120);
+    }
+
+    #[test]
+    fn test_format_empty_tree() {
+        let tree = ReferenceTree::with_search_text("test".to_string());
+        let formatter = TreeFormatter::new();
+        let output = formatter.format(&tree);
+
+        assert!(output.contains("'test'"));
+        assert!(output.contains("search query"));
+    }
+
+    #[test]
+    fn test_format_tree_with_translation() {
+        let mut root = TreeNode::new(NodeType::Root, "add new".to_string());
+        let translation = TreeNode::with_location(
+            NodeType::Translation,
+            "invoice.labels.add_new: 'add new'".to_string(),
+            Location::new(PathBuf::from("en.yml"), 4),
+        );
+        root.add_child(translation);
+
+        let tree = ReferenceTree::new(root);
+        let formatter = TreeFormatter::new();
+        let output = formatter.format(&tree);
+
+        assert!(output.contains("'add new'"));
+        assert!(output.contains("invoice.labels.add_new"));
+        assert!(output.contains("en.yml:4"));
+        assert!(output.contains("└─>") || output.contains("├─>"));
+    }
+
+    #[test]
+    fn test_format_complete_tree() {
+        let mut root = TreeNode::new(NodeType::Root, "add new".to_string());
+
+        let mut translation = TreeNode::with_location(
+            NodeType::Translation,
+            "invoice.labels.add_new: 'add new'".to_string(),
+            Location::new(PathBuf::from("en.yml"), 4),
+        );
+
+        let mut key_path = TreeNode::new(
+            NodeType::KeyPath,
+            "invoice.labels.add_new".to_string(),
+        );
+
+        let code_ref = TreeNode::with_location(
+            NodeType::CodeRef,
+            "I18n.t('invoice.labels.add_new')".to_string(),
+            Location::new(PathBuf::from("invoices.ts"), 14),
+        );
+
+        key_path.add_child(code_ref);
+        translation.add_child(key_path);
+        root.add_child(translation);
+
+        let tree = ReferenceTree::new(root);
+        let formatter = TreeFormatter::new();
+        let output = formatter.format(&tree);
+
+        // Verify all parts are present
+        assert!(output.contains("'add new'"));
+        assert!(output.contains("invoice.labels.add_new"));
+        assert!(output.contains("Key:"));
+        assert!(output.contains("Code:"));
+        assert!(output.contains("I18n.t"));
+        assert!(output.contains("en.yml:4"));
+        assert!(output.contains("invoices.ts:14"));
+    }
+
+    #[test]
+    fn test_format_multiple_children() {
+        let mut root = TreeNode::new(NodeType::Root, "test".to_string());
+
+        let child1 = TreeNode::with_location(
+            NodeType::Translation,
+            "key1: 'value1'".to_string(),
+            Location::new(PathBuf::from("file1.yml"), 1),
+        );
+
+        let child2 = TreeNode::with_location(
+            NodeType::Translation,
+            "key2: 'value2'".to_string(),
+            Location::new(PathBuf::from("file2.yml"), 2),
+        );
+
+        root.add_child(child1);
+        root.add_child(child2);
+
+        let tree = ReferenceTree::new(root);
+        let formatter = TreeFormatter::new();
+        let output = formatter.format(&tree);
+
+        // Should have both children
+        assert!(output.contains("key1"));
+        assert!(output.contains("key2"));
+        assert!(output.contains("file1.yml:1"));
+        assert!(output.contains("file2.yml:2"));
+
+        // Should have proper tree connectors
+        assert!(output.contains("├─>"));
+        assert!(output.contains("└─>"));
+    }
+
+    #[test]
+    fn test_truncate_long_content() {
+        let formatter = TreeFormatter::with_width(50);
+        let long_string = "a".repeat(100);
+        let truncated = formatter.truncate(&long_string, 20);
+
+        assert!(truncated.len() <= 20);
+        assert!(truncated.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_short_content() {
+        let formatter = TreeFormatter::new();
+        let short_string = "short";
+        let result = formatter.truncate(short_string, 20);
+
+        assert_eq!(result, "short");
+    }
+
+    #[test]
+    fn test_format_content_root() {
+        let formatter = TreeFormatter::new();
+        let node = TreeNode::new(NodeType::Root, "test query".to_string());
+        let content = formatter.format_content(&node);
+
+        assert!(content.contains("test query"));
+        assert!(content.contains("search query"));
+    }
+
+    #[test]
+    fn test_format_content_key_path() {
+        let formatter = TreeFormatter::new();
+        let node = TreeNode::new(NodeType::KeyPath, "invoice.labels.add_new".to_string());
+        let content = formatter.format_content(&node);
+
+        assert!(content.contains("Key:"));
+        assert!(content.contains("invoice.labels.add_new"));
+    }
+
+    #[test]
+    fn test_format_content_code_ref() {
+        let formatter = TreeFormatter::new();
+        let node = TreeNode::new(
+            NodeType::CodeRef,
+            "  I18n.t('invoice.labels.add_new')  ".to_string(),
+        );
+        let content = formatter.format_content(&node);
+
+        assert!(content.contains("Code:"));
+        assert!(content.contains("I18n.t"));
+        // Should trim whitespace
+        assert!(!content.starts_with("  "));
+    }
+
+    #[test]
+    fn test_format_deep_nesting() {
+        let mut root = TreeNode::new(NodeType::Root, "test".to_string());
+        let mut level1 = TreeNode::new(NodeType::Translation, "level1".to_string());
+        let mut level2 = TreeNode::new(NodeType::KeyPath, "level2".to_string());
+        let level3 = TreeNode::new(NodeType::CodeRef, "level3".to_string());
+
+        level2.add_child(level3);
+        level1.add_child(level2);
+        root.add_child(level1);
+
+        let tree = ReferenceTree::new(root);
+        let formatter = TreeFormatter::new();
+        let output = formatter.format(&tree);
+
+        // Should have proper indentation
+        let lines: Vec<&str> = output.lines().collect();
+        assert!(lines.len() >= 4);
+
+        // Check that deeper levels have more indentation
+        assert!(lines[2].starts_with(' ') || lines[2].starts_with('│'));
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,3 @@
+pub mod formatter;
+
+pub use formatter::TreeFormatter;

--- a/tests/formatter_test.rs
+++ b/tests/formatter_test.rs
@@ -1,0 +1,189 @@
+use cs::{run_search, ReferenceTreeBuilder, SearchQuery, TreeFormatter};
+use std::path::PathBuf;
+
+#[test]
+fn test_format_search_results() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+
+    println!("\n{}", output);
+
+    // Verify output contains expected elements
+    assert!(output.contains("'add new'"));
+    assert!(output.contains("search query"));
+    assert!(output.contains("invoice.labels.add_new"));
+    assert!(output.contains("Key:"));
+    assert!(output.contains("Code:"));
+}
+
+#[test]
+fn test_format_with_custom_width() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    
+    let formatter = TreeFormatter::with_width(120);
+    let output = formatter.format(&tree);
+
+    println!("\n=== Wide Format (120 columns) ===\n{}", output);
+
+    assert!(output.contains("'add new'"));
+}
+
+#[test]
+fn test_format_no_results() {
+    let query = SearchQuery::new("nonexistent xyz".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+
+    println!("\n=== No Results ===\n{}", output);
+
+    assert!(output.contains("'nonexistent xyz'"));
+    assert!(output.contains("search query"));
+    // Should only have the root node
+    assert_eq!(output.lines().count(), 1);
+}
+
+#[test]
+fn test_format_tree_structure() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+
+    // Check for tree structure characters
+    assert!(output.contains("└─>") || output.contains("├─>"));
+    
+    // Check for proper indentation (spaces or tree characters)
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines.len() > 1, "Should have multiple lines");
+}
+
+#[test]
+fn test_end_to_end_with_formatter() {
+    println!("\n=== End-to-End with Formatter ===\n");
+    
+    let search_text = "add new";
+    println!("Searching for: '{}'", search_text);
+    
+    let query = SearchQuery::new(search_text.to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+    
+    println!("1. Running search...");
+    let result = run_search(query).expect("Search should succeed");
+    println!("   Found {} translations, {} code references", 
+        result.translation_entries.len(), 
+        result.code_references.len());
+    
+    println!("2. Building tree...");
+    let tree = ReferenceTreeBuilder::build(&result);
+    println!("   Tree has {} nodes, depth {}", 
+        tree.node_count(), 
+        tree.max_depth());
+    
+    println!("3. Formatting output...\n");
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+    
+    println!("{}", output);
+    
+    println!("\n✅ End-to-end workflow complete!");
+    
+    assert!(!output.is_empty());
+    assert!(output.contains("'add new'"));
+}
+
+#[test]
+fn test_format_multiple_translations() {
+    let query = SearchQuery::new("invoice".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+
+    println!("\n=== Multiple Translations ===\n{}", output);
+
+    // Should have multiple translation entries
+    assert!(output.contains("invoice"));
+    
+    // Count the number of translation nodes (lines with .yml)
+    let yml_count = output.lines().filter(|line| line.contains(".yml")).count();
+    assert!(yml_count > 0, "Should have at least one translation file reference");
+}
+
+#[test]
+fn test_format_shows_locations() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+
+    // Should show file locations with line numbers
+    assert!(output.contains(".yml:"));
+    assert!(output.contains(".ts:") || output.contains(".tsx:"));
+}
+
+#[test]
+fn test_format_readable_output() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    let formatter = TreeFormatter::new();
+    let output = formatter.format(&tree);
+
+    println!("\n=== Readable Output Test ===\n{}", output);
+
+    // Verify output is human-readable
+    assert!(output.contains("Key:"), "Should label key paths");
+    assert!(output.contains("Code:"), "Should label code references");
+    assert!(output.contains("search query"), "Should label root");
+    
+    // Verify no truncation artifacts in short content
+    assert!(!output.contains("...") || output.len() > 500, 
+        "Short content should not be truncated");
+}
+
+#[test]
+fn test_format_comparison() {
+    let query = SearchQuery::new("add new".to_string())
+        .with_base_dir(PathBuf::from("tests/fixtures/rails-app"));
+
+    let result = run_search(query).expect("Search should succeed");
+    let tree = ReferenceTreeBuilder::build(&result);
+    
+    println!("\n=== Format Comparison ===\n");
+    
+    println!("--- 80 columns ---");
+    let formatter_80 = TreeFormatter::with_width(80);
+    let output_80 = formatter_80.format(&tree);
+    println!("{}", output_80);
+    
+    println!("\n--- 120 columns ---");
+    let formatter_120 = TreeFormatter::with_width(120);
+    let output_120 = formatter_120.format(&tree);
+    println!("{}", output_120);
+    
+    // Both should have the same structure
+    assert_eq!(output_80.lines().count(), output_120.lines().count());
+}


### PR DESCRIPTION
- Add TreeFormatter for rendering reference trees as text
- Format hierarchical tree structure with visual connectors (├─>, └─>)
- Display file locations with line numbers
- Truncate long content to fit within max width (default 80 columns)
- Format different node types appropriately (Root, Translation, KeyPath, CodeRef)
- Comprehensive unit tests (12 tests, all passing)
- Integration tests with real search results (9 tests)

Output format:
'search query' (search query)
├─> translation: 'value' (file.yml:4)
│   └─> Key: translation.key
│       ├─> Code: I18n.t('key') (file.ts:14)
│       └─> Code: t('key') (file.rb:20)

Closes #11