### PR TITLE
fix: update integration tests to match tree format output

### DIFF
--- a/tests/integration/basic_search.rs
+++ b/tests/integration/basic_search.rs
@@ -23,13 +23,15 @@ fn test_basic_search_shows_complete_chain() {
         .current_dir("tests/fixtures/rails-app")
         .assert()
         .success()
-        .stdout(predicate::str::contains("=== Translation Files ==="))
+        .stdout(predicate::str::contains("'add new'"))
+        .stdout(predicate::str::contains("search query"))
         .stdout(predicate::str::contains("invoice.labels.add_new"))
         .stdout(predicate::str::contains("en.yml"))
-        .stdout(predicate::str::contains("=== Code References ==="))
+        .stdout(predicate::str::contains("Key:"))
+        .stdout(predicate::str::contains("Code:"))
         .stdout(predicate::str::contains("invoices.ts"))
-        .stdout(predicate::str::contains(":14:")) // Line number verification
-        .stdout(predicate::str::contains("I18n.t"));
+        .stdout(predicate::str::contains(":14)")) // Line number verification
+        .stdout(predicate::str::contains("├─>").or(predicate::str::contains("└─>")));
 }
 
 #[test]

--- a/tests/integration/multi_match.rs
+++ b/tests/integration/multi_match.rs
@@ -20,7 +20,7 @@ fn test_multiple_code_references_all_shown() {
         .success()
         .stdout(predicate::str::contains("invoice_list.ts"))
         .stdout(predicate::str::contains("invoices.ts"))
-        .stdout(predicate::str::contains("I18n.t").count(5)); // Multiple usages
+        .stdout(predicate::str::contains("Code:").count(4)); // Multiple usages
 }
 
 #[test]
@@ -34,9 +34,9 @@ fn test_multiple_usages_show_line_numbers() {
         .current_dir("tests/fixtures/rails-app")
         .assert()
         .success()
-        .stdout(predicate::str::contains(":12:"))
-        .stdout(predicate::str::contains(":14:"))
-        .stdout(predicate::str::contains(":22:"));
+        .stdout(predicate::str::contains(":12)"))
+        .stdout(predicate::str::contains(":14)"))
+        .stdout(predicate::str::contains(":22)"));
 }
 
 #[test]
@@ -97,7 +97,8 @@ fn test_related_usages_grouped() {
         .current_dir("tests/fixtures/rails-app")
         .assert()
         .success()
-        .stdout(predicate::str::contains("=== Code References ==="));
+        .stdout(predicate::str::contains("Code:"))
+        .stdout(predicate::str::contains("├─>").or(predicate::str::contains("└─>")));
 }
 
 #[test]


### PR DESCRIPTION
- Updated basic_search tests to expect tree format instead of section headers
- Updated multi_match tests to check for 'Code:' instead of 'I18n.t' count
- Updated line number assertions to match tree format (:N) instead of (:N:)
- All 241 tests now passing