### PR TITLE
docs: fix cargo install command to use correct package name

### DIFF
--- a/.specify/specs/code-search/plan.md
+++ b/.specify/specs/code-search/plan.md
@@ -47,7 +47,7 @@ Implement a lightweight CLI tool in **Rust** that automates tracing UI text thro
 
 **Deployment**: Distributed as standalone executable via:
 - GitHub Releases (pre-compiled binaries)
-- Cargo (source distribution: `cargo install code-search`)
+- Cargo (source distribution: `cargo install code-search-cli`)
 - Homebrew formula (macOS: `brew install code-search`)
 - Debian package (Linux: `apt install code-search`)
 
@@ -813,7 +813,7 @@ criterion_main!(benches);
 6. **Announce**: Post release notes in README
 
 ### Distribution Channels
-- **Cargo**: `cargo install code-search`
+- **Cargo**: `cargo install code-search-cli`
 - **GitHub Releases**: Download pre-compiled binaries
 - **Homebrew** (Phase 2): `brew install code-search`
 - **Debian Package** (Phase 3): `apt install code-search`

--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -492,7 +492,7 @@ patterns:
 ### Option 1: Cargo + GitHub Releases ⭐ RECOMMENDED
 
 **Distribution Channels**:
-- **Cargo**: `cargo install code-search` (source distribution)
+- **Cargo**: `cargo install code-search-cli` (source distribution)
 - **GitHub Releases**: Pre-compiled binaries (Linux, macOS, Windows)
 - **Manual**: Download binary, add to PATH
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,7 +19,7 @@ npm install -g code-search-cli
 
 ### Cargo (Rust)
 ```bash
-cargo install code-search
+cargo install code-search-cli
 ```
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ npm install -g code-search-cli
 
 ### Cargo (Rust)
 ```bash
-cargo install code-search
+cargo install code-search-cli
 ```
 
 ### From Binary


### PR DESCRIPTION
## Problem

Our documentation incorrectly instructs users to install via:
```bash
cargo install code-search
```

However, our package on crates.io is named `code-search-cli`. There's a different, unrelated package called `code-search` (v0.0.3) on crates.io.

This causes users who follow our documentation to install the **wrong package**, which has different CLI parameters and functionality.

## Solution

Updated all documentation to use the correct package name:
```bash
cargo install code-search-cli
```

## Files Changed

- ✅ README.md - Installation instructions
- ✅ GETTING_STARTED.md - Installation instructions  
- ✅ EVALUATION.md - Distribution channels section
- ✅ .specify/specs/code-search/plan.md - Distribution channels and deployment sections

## Testing

Verified that:
- `cargo search code-search` shows both packages (ours is `code-search-cli`)
- `cargo install code-search-cli` correctly installs our package
- All tests pass

Fixes #102