### PR TITLE
fix: disable ERB support to resolve tree-sitter version conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tree-sitter-typescript = "0.20.3"
 tree-sitter-python = "0.20.3"
 tree-sitter-ruby = "0.20.1"
 tree-sitter-c-sharp = "0.20.0"
-tree-sitter-embedded-template = "0.20.0"
+# tree-sitter-embedded-template = "0.20.0" # Temporarily disabled due to tree-sitter version conflict
 # Caching dependencies
 sled = "0.34"
 bincode = "1.3"

--- a/src/parse/sitter.rs
+++ b/src/parse/sitter.rs
@@ -12,7 +12,7 @@ pub enum SupportedLanguage {
     TypeScript,
     Ruby,
     CSharp,
-    Erb,
+    // Erb, // Temporarily disabled due to tree-sitter version conflict
 }
 
 impl SupportedLanguage {
@@ -24,7 +24,7 @@ impl SupportedLanguage {
             "ts" | "tsx" => Some(Self::TypeScript),
             "rb" => Some(Self::Ruby),
             "cs" => Some(Self::CSharp),
-            "erb" => Some(Self::Erb),
+            // "erb" => Some(Self::Erb), // Temporarily disabled
             _ => None,
         }
     }
@@ -37,7 +37,7 @@ impl SupportedLanguage {
             Self::TypeScript => tree_sitter_typescript::language_typescript(),
             Self::Ruby => tree_sitter_ruby::language(),
             Self::CSharp => tree_sitter_c_sharp::language(),
-            Self::Erb => tree_sitter_embedded_template::language(),
+            // Self::Erb => tree_sitter_embedded_template::language(),
         }
     }
 }
@@ -100,8 +100,8 @@ impl Sitter {
                     (export_statement (function_declaration name: (identifier) @name))
                     (method_definition name: (property_identifier) @name)
                     (arrow_function) @arrow
-                    (variable_declarator 
-                        name: (identifier) @name 
+                    (variable_declarator
+                        name: (identifier) @name
                         value: (arrow_function))
                 "#
                 }
@@ -116,8 +116,7 @@ impl Sitter {
                     (method_declaration name: (identifier) @name)
                     (local_function_statement name: (identifier) @name)
                 "#
-                }
-                SupportedLanguage::Erb => "", // ERB usually doesn't define functions
+                } // SupportedLanguage::Erb => "", // ERB usually doesn't define functions
             };
 
             let query = Query::new(lang.language(), query_str)


### PR DESCRIPTION
The tree-sitter-embedded-template crate v0.20.0 specifies 'tree-sitter >= 0.20' which allows Cargo to resolve to incompatible versions like 0.22.6 in CI environments, causing type mismatches.

Temporarily disable ERB support until we can upgrade to tree-sitter 0.22+ across all language parsers, or find an alternative solution.

This resolves the CI build error while maintaining all other functionality.